### PR TITLE
Adicionanod o Lucide UI Icons na lista e pequenas atualizações

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Abaixo você encontra materiais para te ajudar a se tornar um desenvolvedor ou s
 
 | Nome         | Descrição     | Site |
 |--------------|-----------|------------|
-| Atom | Editor de código do GitHub. | [Link](https://atom.io/) |
+| 🧡 Atom | Editor de código do GitHub. (descontinuado😭) | [Link](https://atom.io/) |
 | BBEdit | Editor de código para Mac OS. | [Link](https://www.barebones.com/products/bbedit/) |
 | Beekeeper Studio | Editor de código SQL e gerenciador de banco de dados. | [Link](https://www.beekeeperstudio.io/) |
 | Brackets | Editor de código da Adobe. | [Link](http://brackets.io/) |
@@ -507,7 +507,7 @@ Abaixo você encontra materiais para te ajudar a se tornar um desenvolvedor ou s
 | ❤️ JavaScript | Constante evolução e crescimento no mercado. | [Link](http://brasil.js.org) |
 | Julia | Linguagem de programação de código aberto e alto desempenho para computação técnica. | [Link](https://julialang.org/) |
 | Kotlin | Linguagem de programação multiplataforma, orientada a objetos compila para a MVJ. | [Link](https://kotlinlang.org/) |
-| Lua | Linguagem de programação originária do Brasil, permite programação procedural e POO (popular em jogos). | [Link](https://www.lua.org/portugues.html) |
+| 🧡 Lua Script | Linguagem de programação originária do Brasil, permite programação procedural e POO (popular em jogos). | [Link](https://www.lua.org/portugues.html) |
 | MatLab | Linguagem de programação de alto nível com foco em cálculos e construção de gráficos. | [Link](https://www.mathworks.com/help/matlab/) |
 | Pascal | Linguagem de programação imperativa, estruturada e orientada à objetos. | [Link](https://docs.freepascal.org/) |
 | Perl | Linguagem de programação multiplataforma e dinâmica. | [Link](https://www.perl.org/) |
@@ -658,7 +658,7 @@ Abaixo você encontra materiais para te ajudar a se tornar um desenvolvedor ou s
 | GoDaddy | Empresa de aluguel de servidores compartilhados, dedicados e registro de domínio | [Link](https://br.godaddy.com/) |
 | GoDaddy | Hospedagem de sites internacional | [Link](https://br.godaddy.com/hosting/web-hosting) |
 | Google Cloud | Serviço de aluguel de servidores da Google | [Link](https://cloud.google.com/solutions/smb/web-hosting/) |
-| Heroku | Hospedagem de sites grátis com suporte à NodeJS, Java, Ruby, PHP, Python, Go, Scala e Clojure | [Link](https://www.heroku.com/) |
+| Heroku | Hospedagem de sites ~grátis~ com suporte à NodeJS, Java, Ruby, PHP, Python, Go, Scala e Clojure | [Link](https://www.heroku.com/) |
 | HostGator | Hospedagem compartilhada e dedicada para sites e serviços | [Link](https://www.hostgator.com/) |
 | Hostinger | Hospedagem de sites em cloud computing dedicado | [Link](https://www.hostinger.com.br/) |
 | Hostoo | Empresa que descomplica a hospedagem de sites e aplicações PHP para você focar no seu negócio. | [Link](https://hostoo.io/) |
@@ -714,7 +714,8 @@ Abaixo você encontra materiais para te ajudar a se tornar um desenvolvedor ou s
 | Life of Pix | Banco de imagens gratuitas. | [Link](https://www.lifeofpix.com/) |
 | Little Visuals | Banco de imagens gratuitas. | [Link](https://littlevisuals.co/) |
 | Lorempixel | Banco de imagens para uso como template. | [Link](http://lorempixel.com/) |
-| Lukas Zadam | Ilustrações SVG em diferentes tamanhos e estilos. | [Link](https://lukaszadam.com/illustrations) |
+| 🧡 Lucide | Lucide é uma biblioteca de ícones de código aberto para exibição de ícones e símbolos em projetos digitais e não digitais. A biblioteca tem como objetivo facilitar a incorporação de ícones em seus projetos por designers e desenvolvedores |
+| Lukas Zadam | Ilustrações SVG em diferentes tamanhos e estilos. | [Link](https://lucide.dev/) |
 | ManyPixels | Galeria de ilustrações com direito a edição de cores. | [Link](https://www.manypixels.co/gallery/) |
 | Morguefile | Banco de imagens gratuitas. | [Link](https://morguefile.com/) |
 | Nappy | Banco de imagens gratuitas (atribuição recomendada). | [Link](https://www.nappy.co) |

--- a/README.md
+++ b/README.md
@@ -714,8 +714,8 @@ Abaixo você encontra materiais para te ajudar a se tornar um desenvolvedor ou s
 | Life of Pix | Banco de imagens gratuitas. | [Link](https://www.lifeofpix.com/) |
 | Little Visuals | Banco de imagens gratuitas. | [Link](https://littlevisuals.co/) |
 | Lorempixel | Banco de imagens para uso como template. | [Link](http://lorempixel.com/) |
-| 🧡 Lucide | Lucide é uma biblioteca de ícones de código aberto para exibição de ícones e símbolos em projetos digitais e não digitais. A biblioteca tem como objetivo facilitar a incorporação de ícones em seus projetos por designers e desenvolvedores |
-| Lukas Zadam | Ilustrações SVG em diferentes tamanhos e estilos. | [Link](https://lucide.dev/) |
+| 🧡 Lucide | Lucide é uma biblioteca de ícones de código aberto para exibição de ícones e símbolos em projetos digitais e não digitais. A biblioteca tem como objetivo facilitar a incorporação de ícones em seus projetos por designers e desenvolvedores |[Link](https://lucide.dev/) |
+| Lukas Zadam | Ilustrações SVG em diferentes tamanhos e estilos. | [Link](https://lukaszadam.com/illustrations) |
 | ManyPixels | Galeria de ilustrações com direito a edição de cores. | [Link](https://www.manypixels.co/gallery/) |
 | Morguefile | Banco de imagens gratuitas. | [Link](https://morguefile.com/) |
 | Nappy | Banco de imagens gratuitas (atribuição recomendada). | [Link](https://www.nappy.co) |


### PR DESCRIPTION
A IDE atom foi descontinuada, com a compra do github da Microsoft, e a MS já tendo o VScode, resolveu descontinuar o atom.

A Heroku não tem mais os planos gratuitos

Atualizei o nome da linguagem de programação de "lua" para o nome completo "Lua Script"

comentado em #4 